### PR TITLE
Update .NET target framework and bump to 1.2.3

### DIFF
--- a/Hagelkorn.Tests/Hagelkorn.Tests.csproj
+++ b/Hagelkorn.Tests/Hagelkorn.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
 

--- a/Hagelkorn/Hagelkorn.csproj
+++ b/Hagelkorn/Hagelkorn.csproj
@@ -6,9 +6,9 @@
     <Authors>Michael Osthege</Authors>
     <Company>Forschungszentrum Jülich GmbH</Company>
     <Product>Hagelkorn</Product>
-    <Version>1.2.1</Version>
-    <AssemblyVersion>1.2.1.0</AssemblyVersion>
-    <FileVersion>1.2.1.0</FileVersion>
+    <Version>1.2.3</Version>
+    <AssemblyVersion>1.2.3.0</AssemblyVersion>
+    <FileVersion>1.2.3.0</FileVersion>
     <PackageId>Hagelkorn</PackageId>
     <AssemblyName>Hagelkorn</AssemblyName>
     <RootNamespace>Hagelkorn</RootNamespace>

--- a/Hagelkorn/Hagelkorn.csproj
+++ b/Hagelkorn/Hagelkorn.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Michael Osthege</Authors>
     <Company>Forschungszentrum Jülich GmbH</Company>

--- a/pyhagelkorn/hagelkorn/__init__.py
+++ b/pyhagelkorn/hagelkorn/__init__.py
@@ -1,3 +1,3 @@
 from .core import HagelSource, Resolution, monotonic, random
 
-__version__ = "1.2.2"
+__version__ = "1.2.3"


### PR DESCRIPTION
Going to 1.2.3 for both C# and Python package so I can make a release for a Zenodo DOI.

At the same time, I'm updating to .NET 5.0 which is currently in LTS and compatible with VS 2019.